### PR TITLE
Fix subscription with salesforce

### DIFF
--- a/extensions/replay/replay_test.go
+++ b/extensions/replay/replay_test.go
@@ -99,7 +99,7 @@ func TestIncomingMetaUnsubscribeRemovesChannel(t *testing.T) {
 	}}
 	m := bayeux.Message{
 		Channel:      bayeux.MetaUnsubscribe,
-		Subscription: []bayeux.Channel{"/"},
+		Subscription: bayeux.Channel("/"),
 	}
 	e.Incoming(&m)
 

--- a/message.go
+++ b/message.go
@@ -87,7 +87,7 @@ type Message struct {
 	// to/from the `/meta/subscribe` or `/meta/unsubscribe` channels.
 	//
 	// See also: https://docs.cometd.org/current/reference/#_subscription
-	Subscription []Channel `json:"subscription,omitempty"`
+	Subscription Channel `json:"subscription,omitempty"`
 	// Error field is optional in any response and MAY indicate the type of
 	// error that occurred when a request returns with a false successful
 	// message.

--- a/message_builders.go
+++ b/message_builders.go
@@ -198,14 +198,19 @@ func (b *SubscribeRequestBuilder) Build() ([]Message, error) {
 		return nil, errors.New("no subscriptions provided")
 	}
 
-	m := Message{
-		Channel:      MetaSubscribe,
-		ClientID:     b.clientID,
-		Subscription: b.subscription,
+	ms := make([]Message, len(b.subscription))
+
+	for i := range b.subscription {
+		ms[i] = Message{
+			Channel:      MetaSubscribe,
+			ClientID:     b.clientID,
+			Subscription: b.subscription[i],
+		}
 	}
+
 	// TODO Add the ext and id fields once we're able to handle them with the
 	// builder
-	return []Message{m}, nil
+	return ms, nil
 }
 
 // UnsubscribeRequestBuilder provides an easy way to build a /meta/unsubscribe
@@ -254,14 +259,18 @@ func (b *UnsubscribeRequestBuilder) Build() ([]Message, error) {
 		return nil, errors.New("no subscriptions provided")
 	}
 
-	m := Message{
-		Channel:      MetaUnsubscribe,
-		ClientID:     b.clientID,
-		Subscription: b.subscription,
+	ms := make([]Message, len(b.subscription))
+
+	for i := range b.subscription {
+		ms[i] = Message{
+			Channel:      MetaUnsubscribe,
+			ClientID:     b.clientID,
+			Subscription: b.subscription[i],
+		}
 	}
 	// TODO Add the ext and id fields once we're able to handle them with the
 	// builder
-	return []Message{m}, nil
+	return ms, nil
 }
 
 // DisconnectRequestBuilder provides an easy way to build a /meta/disconnect

--- a/message_example_test.go
+++ b/message_example_test.go
@@ -67,7 +67,7 @@ func ExampleSubscribeRequestBuilder() {
 	}
 	fmt.Println(string(jsonBytes))
 	// Output:
-	// [{"channel":"/meta/subscribe","clientId":"Un1q31d3nt1f13r","subscription":["/foo/**","/bar/foo"]}]
+	// [{"channel":"/meta/subscribe","clientId":"Un1q31d3nt1f13r","subscription":"/foo/**"},{"channel":"/meta/subscribe","clientId":"Un1q31d3nt1f13r","subscription":"/bar/foo"}]
 }
 
 func ExampleUnsubscribeRequestBuilder() {
@@ -92,5 +92,5 @@ func ExampleUnsubscribeRequestBuilder() {
 	}
 	fmt.Println(string(jsonBytes))
 	// Output:
-	// [{"channel":"/meta/unsubscribe","clientId":"Un1q31d3nt1f13r","subscription":["/foo/**","/bar/foo"]}]
+	// [{"channel":"/meta/unsubscribe","clientId":"Un1q31d3nt1f13r","subscription":"/foo/**"},{"channel":"/meta/unsubscribe","clientId":"Un1q31d3nt1f13r","subscription":"/bar/foo"}]
 }


### PR DESCRIPTION
Update Message struct to hold a single subscription instead of a slice.
For multiple subscriptions, pass multiple messages.

This fixes a bug with salesforce CometD where passing the subscription
field as a json list returns an empty body to the `/meta/subscribe`
request.