### PR TITLE
Fix github action to pull enough information

### DIFF
--- a/.github/workflows/commit-linting.yml
+++ b/.github/workflows/commit-linting.yml
@@ -1,6 +1,6 @@
 name: Commit linting
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:
@@ -9,6 +9,14 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        # Checkout the entire pull request branch
+        ref: ${{github.event.pull_request.head.ref}}
+        fetch-depth: ${{github.event.pull_request.commits}}
+    - uses: actions/checkout@v2
+      with:
+        ref: main
+        fetch-depth: 1
     - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/run-gitlint.sh
+++ b/.github/workflows/run-gitlint.sh
@@ -1,8 +1,2 @@
 #!/bin/bash
-
-for commit in $(git rev-list main); do
-    commit_msg=$(git log -1 --pretty=%B $commit)
-    echo "$commit"
-    echo "$commit_msg" | gitlint
-    echo "--------"
-done
+gitlint --commits "main..HEAD"


### PR DESCRIPTION
In the original version of this, the `checkout` action does the *bare*
minimum to test things. As such, `git rev-list` was failing because it
didn't understand the reference to `main`. This updates how and what we
checkout based off of the horribly undocumented features of GitHub
actions. This will check all commits in a PR's branch rather than just
the latest commit on a PR.