### PR TITLE
Convert all errors to concrete or sentinel error types

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -5,40 +5,40 @@
 // The best way to create a high-level client is with `NewClient`. Provided a
 // server address for the server you're using, you can create a client like so
 //
-//    serverAddress := "https://localhost:8080/"
-//    client := gobayeux.NewClient(serverAddress)
+//	serverAddress := "https://localhost:8080/"
+//	client := gobayeux.NewClient(serverAddress)
 //
 // You can also register customer HTTP transports with your client
 //
-//    transport := &http.Transport{
-//    	DialContext: (&net.Dialer{
-//      	Timeout:   3 * time.Second,
-//      	KeepAlive: 10 * time.Second,
-//      }).DialContext,
-//    }
-//    client := gobayeux.NewClient(serverAddress, gobayeux.WithHTTPTransport(transport))
+//	transport := &http.Transport{
+//		DialContext: (&net.Dialer{
+//	  	Timeout:   3 * time.Second,
+//	  	KeepAlive: 10 * time.Second,
+//	  }).DialContext,
+//	}
+//	client := gobayeux.NewClient(serverAddress, gobayeux.WithHTTPTransport(transport))
 //
 // You can subscribe to a Bayeux Channel with a chan to receive messages on
 //
-//    recv := make(chan []gobayeux.Message)
-//    client.Subscribe("example-channel", recv)
+//	recv := make(chan []gobayeux.Message)
+//	client.Subscribe("example-channel", recv)
 //
 // You can also register extensions that you'd like to use with the server
 // by implementing the MessageExtender interface and then passing it to the
 // client
 //
-//    type Example struct {}
-//    func (e *Example) Registered(name string, client *gobayeux.BayeuxClient) {}
-//    func (e *Example) Unregistered() {}
-//    func (e *Example) Outgoing(m *gobayeux.Message) {
-//       switch m.Channel {
-//       case gobayeux.MetaHandshake:
-//       	ext := m.GetExt(true)
-//       	ext["example"] = true
-//       }
-//    }
-//    func (e *Example) Incoming(m *gobayeux.Message) {}
+//	type Example struct {}
+//	func (e *Example) Registered(name string, client *gobayeux.BayeuxClient) {}
+//	func (e *Example) Unregistered() {}
+//	func (e *Example) Outgoing(m *gobayeux.Message) {
+//	   switch m.Channel {
+//	   case gobayeux.MetaHandshake:
+//	   	ext := m.GetExt(true)
+//	   	ext["example"] = true
+//	   }
+//	}
+//	func (e *Example) Incoming(m *gobayeux.Message) {}
 //
-//    e := &Example{}
-//    client.UseExtension(e)
+//	e := &Example{}
+//	client.UseExtension(e)
 package gobayeux

--- a/errors.go
+++ b/errors.go
@@ -6,34 +6,34 @@ import (
 
 const (
 	// ErrClientNotConnected is returned when the client is not connected
-	ErrClientNotConnected = sentinal("client not connected to server")
+	ErrClientNotConnected = sentinel("client not connected to server")
 
 	// ErrTooManyMessages is returned when there is more than one handshake message
-	ErrTooManyMessages = sentinal("more messages than expected in handshake response")
+	ErrTooManyMessages = sentinel("more messages than expected in handshake response")
 
 	// ErrBadChannel is returned when the handshake response is on the wrong channel
-	ErrBadChannel = sentinal("handshake responses must come back via the /meta/handshake channel")
+	ErrBadChannel = sentinel("handshake responses must come back via the /meta/handshake channel")
 
 	// ErrFailedToConnect is a general connection error
-	ErrFailedToConnect = sentinal("connect request was not successful")
+	ErrFailedToConnect = sentinel("connect request was not successful")
 
 	// ErrNoSupportedConnectionTypes is returned when the client and server
 	// aren't able to agree on a connection type
-	ErrNoSupportedConnectionTypes = sentinal("no supported connection types provided")
+	ErrNoSupportedConnectionTypes = sentinel("no supported connection types provided")
 
 	// ErrNoVersion is returned when a version is not provided
-	ErrNoVersion = sentinal("no version specified")
+	ErrNoVersion = sentinel("no version specified")
 
 	// ErrMissingClientID is returned when the client id has not been set
-	ErrMissingClientID = sentinal("missing clientID value")
+	ErrMissingClientID = sentinel("missing clientID value")
 
 	// ErrMissingConnectionType is returned when the connection type is unset
-	ErrMissingConnectionType = sentinal("missing connectionType value")
+	ErrMissingConnectionType = sentinel("missing connectionType value")
 )
 
-type sentinal string
+type sentinel string
 
-func (s sentinal) Error() string {
+func (s sentinel) Error() string {
 	return string(s)
 }
 

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,247 @@
+package gobayeux
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	// ErrClientNotConnected is returned when the client is not connected
+	ErrClientNotConnected = errors.New("client not connected to server")
+
+	// ErrTooManyMessages is returned when there is more than one handshake message
+	ErrTooManyMessages = errors.New("more messages than expected in handshake response")
+
+	// ErrBadChannel is returned when the handshake response is on the wrong channel
+	ErrBadChannel = errors.New("handshake responses must come back via the /meta/handshake channel")
+
+	// ErrFailedToConnect is a general connection error
+	ErrFailedToConnect = errors.New("connect request was not successful")
+
+	// ErrNoSupportedConnectionTypes is returned when the client and server
+	// aren't able to agree on a connection type
+	ErrNoSupportedConnectionTypes = errors.New("no supported connection types provided")
+
+	// ErrNoVersion is returned when a version is not provided
+	ErrNoVersion = errors.New("no version specified")
+
+	// ErrMissingClientID is returned when the client id has not been set
+	ErrMissingClientID = errors.New("missing clientID value")
+
+	// ErrMissingConnectionType is returned when the connection type is unset
+	ErrMissingConnectionType = errors.New("missing connectionType value")
+)
+
+// ErrConnectionFailed is returned whenever Connect is called and it fails
+type ErrConnectionFailed struct {
+	err error
+}
+
+func (e ErrConnectionFailed) Error() string {
+	return fmt.Sprintf("connection failed (%s)", e.err)
+}
+
+func (e ErrConnectionFailed) Unwrap() error {
+	return e.err
+}
+
+// ErrHandshakeFailed is returned whenever the handshake fails
+type ErrHandshakeFailed struct {
+	err error
+}
+
+func (e ErrHandshakeFailed) Error() string {
+	return e.err.Error()
+}
+
+func (e ErrHandshakeFailed) Unwrap() error {
+	return e.err
+}
+
+func newHandshakeError(msg string) *ErrHandshakeFailed {
+	return &ErrHandshakeFailed{
+		fmt.Errorf("handshake was not successful: %s", msg),
+	}
+}
+
+// ErrSubscriptionFailed is returned for any errors on Subscribe
+type ErrSubscriptionFailed struct {
+	Channels []Channel
+	err      error
+}
+
+func (e ErrSubscriptionFailed) Error() string {
+	return fmt.Sprintf("subscription failed (%s)", e.err)
+}
+
+func (e ErrSubscriptionFailed) Unwrap() error {
+	return e.err
+}
+
+// ErrUnsubscribeFailed is returned for any errors on Unsubscribe
+type ErrUnsubscribeFailed struct {
+	Channels []Channel
+	err      error
+}
+
+func (e ErrUnsubscribeFailed) Error() string {
+	return fmt.Sprintf("subscription failed (%s)", e.err)
+}
+
+func (e ErrUnsubscribeFailed) Unwrap() error {
+	return e.err
+}
+
+// ErrActionFailed is a general purpose error returned by the BayeuxClient
+type ErrActionFailed struct {
+	action string
+	err    string
+}
+
+func (e ErrActionFailed) Error() string {
+	return fmt.Sprintf("unable to %s channels: %s", e.action, e.err)
+}
+
+func newSubscribeError(msg string) *ErrActionFailed {
+	return &ErrActionFailed{"subscribe to", msg}
+}
+
+func newUnsubscribeError(msg string) *ErrActionFailed {
+	return &ErrActionFailed{"unsubscribe from", msg}
+}
+
+// ErrDisconnectFailed is returned when the call to Disconnect fails
+type ErrDisconnectFailed struct {
+	err error
+}
+
+func (e ErrDisconnectFailed) Error() string {
+	msg := "unable to disconnect from Bayeux server"
+
+	if e.err == nil {
+		return msg
+	}
+
+	return fmt.Sprintf("%s (%s)", msg, e.err)
+}
+
+func (e ErrDisconnectFailed) Unwrap() error {
+	return e.err
+}
+
+// ErrAlreadyRegistered signifies that the given MessageExtender is already
+// registered with the client
+type ErrAlreadyRegistered struct {
+	MessageExtender
+}
+
+func (e ErrAlreadyRegistered) Error() string {
+	return fmt.Sprintf("extension already registered: %s", e.MessageExtender)
+}
+
+// ErrBadResponse is returned when we get an unexpected HTTP response from the server
+type ErrBadResponse struct {
+	StatusCode int
+	Status     string
+}
+
+func (e ErrBadResponse) Error() string {
+	return fmt.Sprintf(
+		"expected 200 response from bayeux server, got %d with status '%s'",
+		e.StatusCode,
+		e.Status,
+	)
+}
+
+// ErrBadConnectionType is returned when we don't know how to handle the
+// requested connection type
+type ErrBadConnectionType struct {
+	ConnectionType string
+}
+
+func (e ErrBadConnectionType) Error() string {
+	return fmt.Sprintf("%q is not a valid connection type", e.ConnectionType)
+}
+
+// ErrBadConnectionVersion is returned when we can't support the requested
+// version number
+type ErrBadConnectionVersion struct {
+	Version string
+}
+
+func (e ErrBadConnectionVersion) Error() string {
+	return fmt.Sprintf("version %q is invalid for Bayeux protocol", e.Version)
+}
+
+// ErrInvalidChannel is the result of a failure to validate a channel name
+type ErrInvalidChannel struct {
+	Channel
+}
+
+func (e ErrInvalidChannel) Error() string {
+	return fmt.Sprintf("channel %q appears to not be a valid channel", e.Channel)
+}
+
+// ErrEmptySlice is returned when an empty slice is unexpected
+type ErrEmptySlice string
+
+func (e ErrEmptySlice) Error() string {
+	return fmt.Sprintf("no %s provided", string(e))
+}
+
+// ErrMessageUnparsable is returned when we fail to parse a message
+type ErrMessageUnparsable string
+
+func (e ErrMessageUnparsable) Error() string {
+	return fmt.Sprintf("error message not parseable: %s", string(e))
+}
+
+// ErrBadState is returned when the state machine transition is not valid
+type ErrBadState struct {
+	CurrenctState int32
+	FromState     int32
+	ToState       int32
+	msg           string
+}
+
+func (e ErrBadState) Error() string {
+	return fmt.Sprintf("%s, (current: %s, from: %s, to: %s)", e.msg, stateName(e.CurrenctState), stateName(e.FromState), stateName(e.ToState))
+}
+
+// ErrBadHandshake is returned when trying to handshake but not unconnected
+type ErrBadHandshake struct {
+	*ErrBadState
+}
+
+func newBadHanshake(current, from, to int32) *ErrBadHandshake {
+	return &ErrBadHandshake{
+		&ErrBadState{
+			msg:           "attempting to handshake but not in unconnected state",
+			CurrenctState: current,
+			FromState:     from,
+			ToState:       to,
+		},
+	}
+}
+
+// ErrBadConnect is returned when trying to connected but not connecting
+type ErrBadConnect struct {
+	*ErrBadState
+}
+
+func newBadConnect(current, from, to int32) *ErrBadConnect {
+	return &ErrBadConnect{
+		&ErrBadState{
+			msg:           "invalid state for successful connect response event",
+			CurrenctState: current,
+			FromState:     from,
+			ToState:       to,
+		},
+	}
+}
+
+type ErrUnknownEventType string
+
+func (e ErrUnknownEventType) Error() string {
+	return fmt.Sprintf("unknown event type (%q)", string(e))
+}

--- a/errors.go
+++ b/errors.go
@@ -1,36 +1,41 @@
 package gobayeux
 
 import (
-	"errors"
 	"fmt"
 )
 
-var (
+const (
 	// ErrClientNotConnected is returned when the client is not connected
-	ErrClientNotConnected = errors.New("client not connected to server")
+	ErrClientNotConnected = sentinal("client not connected to server")
 
 	// ErrTooManyMessages is returned when there is more than one handshake message
-	ErrTooManyMessages = errors.New("more messages than expected in handshake response")
+	ErrTooManyMessages = sentinal("more messages than expected in handshake response")
 
 	// ErrBadChannel is returned when the handshake response is on the wrong channel
-	ErrBadChannel = errors.New("handshake responses must come back via the /meta/handshake channel")
+	ErrBadChannel = sentinal("handshake responses must come back via the /meta/handshake channel")
 
 	// ErrFailedToConnect is a general connection error
-	ErrFailedToConnect = errors.New("connect request was not successful")
+	ErrFailedToConnect = sentinal("connect request was not successful")
 
 	// ErrNoSupportedConnectionTypes is returned when the client and server
 	// aren't able to agree on a connection type
-	ErrNoSupportedConnectionTypes = errors.New("no supported connection types provided")
+	ErrNoSupportedConnectionTypes = sentinal("no supported connection types provided")
 
 	// ErrNoVersion is returned when a version is not provided
-	ErrNoVersion = errors.New("no version specified")
+	ErrNoVersion = sentinal("no version specified")
 
 	// ErrMissingClientID is returned when the client id has not been set
-	ErrMissingClientID = errors.New("missing clientID value")
+	ErrMissingClientID = sentinal("missing clientID value")
 
 	// ErrMissingConnectionType is returned when the connection type is unset
-	ErrMissingConnectionType = errors.New("missing connectionType value")
+	ErrMissingConnectionType = sentinal("missing connectionType value")
 )
+
+type sentinal string
+
+func (s sentinal) Error() string {
+	return string(s)
+}
 
 // ConnectionFailedError is returned whenever Connect is called and it fails
 type ConnectionFailedError struct {

--- a/errors.go
+++ b/errors.go
@@ -240,6 +240,7 @@ func newBadConnect(current, from, to int32) *ErrBadConnect {
 	}
 }
 
+// ErrUnknownEventType is returned when the next state is unknown
 type ErrUnknownEventType string
 
 func (e ErrUnknownEventType) Error() string {

--- a/errors.go
+++ b/errors.go
@@ -32,120 +32,120 @@ var (
 	ErrMissingConnectionType = errors.New("missing connectionType value")
 )
 
-// ErrConnectionFailed is returned whenever Connect is called and it fails
-type ErrConnectionFailed struct {
-	err error
+// ConnectionFailedError is returned whenever Connect is called and it fails
+type ConnectionFailedError struct {
+	Err error
 }
 
-func (e ErrConnectionFailed) Error() string {
-	return fmt.Sprintf("connection failed (%s)", e.err)
+func (e ConnectionFailedError) Error() string {
+	return fmt.Sprintf("connection failed (%s)", e.Err)
 }
 
-func (e ErrConnectionFailed) Unwrap() error {
-	return e.err
+func (e ConnectionFailedError) Unwrap() error {
+	return e.Err
 }
 
-// ErrHandshakeFailed is returned whenever the handshake fails
-type ErrHandshakeFailed struct {
-	err error
+// HandshakeFailedError is returned whenever the handshake fails
+type HandshakeFailedError struct {
+	Err error
 }
 
-func (e ErrHandshakeFailed) Error() string {
-	return e.err.Error()
+func (e HandshakeFailedError) Error() string {
+	return e.Err.Error()
 }
 
-func (e ErrHandshakeFailed) Unwrap() error {
-	return e.err
+func (e HandshakeFailedError) Unwrap() error {
+	return e.Err
 }
 
-func newHandshakeError(msg string) *ErrHandshakeFailed {
-	return &ErrHandshakeFailed{
+func newHandshakeError(msg string) *HandshakeFailedError {
+	return &HandshakeFailedError{
 		fmt.Errorf("handshake was not successful: %s", msg),
 	}
 }
 
-// ErrSubscriptionFailed is returned for any errors on Subscribe
-type ErrSubscriptionFailed struct {
+// SubscriptionFailedError is returned for any errors on Subscribe
+type SubscriptionFailedError struct {
 	Channels []Channel
-	err      error
+	Err      error
 }
 
-func (e ErrSubscriptionFailed) Error() string {
-	return fmt.Sprintf("subscription failed (%s)", e.err)
+func (e SubscriptionFailedError) Error() string {
+	return fmt.Sprintf("subscription failed (%s)", e.Err)
 }
 
-func (e ErrSubscriptionFailed) Unwrap() error {
-	return e.err
+func (e SubscriptionFailedError) Unwrap() error {
+	return e.Err
 }
 
-// ErrUnsubscribeFailed is returned for any errors on Unsubscribe
-type ErrUnsubscribeFailed struct {
+// UnsubscribeFailedError is returned for any errors on Unsubscribe
+type UnsubscribeFailedError struct {
 	Channels []Channel
-	err      error
+	Err      error
 }
 
-func (e ErrUnsubscribeFailed) Error() string {
-	return fmt.Sprintf("subscription failed (%s)", e.err)
+func (e UnsubscribeFailedError) Error() string {
+	return fmt.Sprintf("subscription failed (%s)", e.Err)
 }
 
-func (e ErrUnsubscribeFailed) Unwrap() error {
-	return e.err
+func (e UnsubscribeFailedError) Unwrap() error {
+	return e.Err
 }
 
-// ErrActionFailed is a general purpose error returned by the BayeuxClient
-type ErrActionFailed struct {
-	action string
-	err    string
+// ActionFailedError is a general purpose error returned by the BayeuxClient
+type ActionFailedError struct {
+	Action       string
+	ErrorMessage string
 }
 
-func (e ErrActionFailed) Error() string {
-	return fmt.Sprintf("unable to %s channels: %s", e.action, e.err)
+func (e ActionFailedError) Error() string {
+	return fmt.Sprintf("unable to %s channels: %s", e.Action, e.ErrorMessage)
 }
 
-func newSubscribeError(msg string) *ErrActionFailed {
-	return &ErrActionFailed{"subscribe to", msg}
+func newSubscribeError(msg string) *ActionFailedError {
+	return &ActionFailedError{"subscribe to", msg}
 }
 
-func newUnsubscribeError(msg string) *ErrActionFailed {
-	return &ErrActionFailed{"unsubscribe from", msg}
+func newUnsubscribeError(msg string) *ActionFailedError {
+	return &ActionFailedError{"unsubscribe from", msg}
 }
 
-// ErrDisconnectFailed is returned when the call to Disconnect fails
-type ErrDisconnectFailed struct {
-	err error
+// DisconnectFailedError is returned when the call to Disconnect fails
+type DisconnectFailedError struct {
+	Err error
 }
 
-func (e ErrDisconnectFailed) Error() string {
+func (e DisconnectFailedError) Error() string {
 	msg := "unable to disconnect from Bayeux server"
 
-	if e.err == nil {
+	if e.Err == nil {
 		return msg
 	}
 
-	return fmt.Sprintf("%s (%s)", msg, e.err)
+	return fmt.Sprintf("%s (%s)", msg, e.Err)
 }
 
-func (e ErrDisconnectFailed) Unwrap() error {
-	return e.err
+func (e DisconnectFailedError) Unwrap() error {
+	return e.Err
 }
 
-// ErrAlreadyRegistered signifies that the given MessageExtender is already
+// AlreadyRegisteredError signifies that the given MessageExtender is already
 // registered with the client
-type ErrAlreadyRegistered struct {
+type AlreadyRegisteredError struct {
 	MessageExtender
 }
 
-func (e ErrAlreadyRegistered) Error() string {
+func (e AlreadyRegisteredError) Error() string {
 	return fmt.Sprintf("extension already registered: %s", e.MessageExtender)
 }
 
-// ErrBadResponse is returned when we get an unexpected HTTP response from the server
-type ErrBadResponse struct {
+// BadResponseError is returned when we get an unexpected HTTP response from the server
+type BadResponseError struct {
 	StatusCode int
 	Status     string
 }
 
-func (e ErrBadResponse) Error() string {
+func (e BadResponseError) Error() string {
 	return fmt.Sprintf(
 		"expected 200 response from bayeux server, got %d with status '%s'",
 		e.StatusCode,
@@ -153,39 +153,39 @@ func (e ErrBadResponse) Error() string {
 	)
 }
 
-// ErrBadConnectionType is returned when we don't know how to handle the
+// BadConnectionTypeError is returned when we don't know how to handle the
 // requested connection type
-type ErrBadConnectionType struct {
+type BadConnectionTypeError struct {
 	ConnectionType string
 }
 
-func (e ErrBadConnectionType) Error() string {
+func (e BadConnectionTypeError) Error() string {
 	return fmt.Sprintf("%q is not a valid connection type", e.ConnectionType)
 }
 
-// ErrBadConnectionVersion is returned when we can't support the requested
+// BadConnectionVersionError is returned when we can't support the requested
 // version number
-type ErrBadConnectionVersion struct {
+type BadConnectionVersionError struct {
 	Version string
 }
 
-func (e ErrBadConnectionVersion) Error() string {
+func (e BadConnectionVersionError) Error() string {
 	return fmt.Sprintf("version %q is invalid for Bayeux protocol", e.Version)
 }
 
-// ErrInvalidChannel is the result of a failure to validate a channel name
-type ErrInvalidChannel struct {
+// InvalidChannelError is the result of a failure to validate a channel name
+type InvalidChannelError struct {
 	Channel
 }
 
-func (e ErrInvalidChannel) Error() string {
+func (e InvalidChannelError) Error() string {
 	return fmt.Sprintf("channel %q appears to not be a valid channel", e.Channel)
 }
 
-// ErrEmptySlice is returned when an empty slice is unexpected
-type ErrEmptySlice string
+// EmptySliceError is returned when an empty slice is unexpected
+type EmptySliceError string
 
-func (e ErrEmptySlice) Error() string {
+func (e EmptySliceError) Error() string {
 	return fmt.Sprintf("no %s provided", string(e))
 }
 
@@ -196,53 +196,55 @@ func (e ErrMessageUnparsable) Error() string {
 	return fmt.Sprintf("error message not parseable: %s", string(e))
 }
 
-// ErrBadState is returned when the state machine transition is not valid
-type ErrBadState struct {
-	CurrenctState int32
-	FromState     int32
-	ToState       int32
-	msg           string
+// BadStateError is returned when the state machine transition is not valid
+type BadStateError struct {
+	CurrentState int32
+	FromState    int32
+	ToState      int32
+	Message      string
 }
 
-func (e ErrBadState) Error() string {
-	return fmt.Sprintf("%s, (current: %s, from: %s, to: %s)", e.msg, stateName(e.CurrenctState), stateName(e.FromState), stateName(e.ToState))
+func (e BadStateError) Error() string {
+	return fmt.Sprintf("%s, (current: %s, from: %s, to: %s)", e.Message, stateName(e.CurrentState), stateName(e.FromState), stateName(e.ToState))
 }
 
-// ErrBadHandshake is returned when trying to handshake but not unconnected
-type ErrBadHandshake struct {
-	*ErrBadState
+// BadHandshakeError is returned when trying to handshake but not unconnected
+type BadHandshakeError struct {
+	*BadStateError
 }
 
-func newBadHanshake(current, from, to int32) *ErrBadHandshake {
-	return &ErrBadHandshake{
-		&ErrBadState{
-			msg:           "attempting to handshake but not in unconnected state",
-			CurrenctState: current,
-			FromState:     from,
-			ToState:       to,
+func newBadHanshake(current, from, to int32) *BadHandshakeError {
+	return &BadHandshakeError{
+		&BadStateError{
+			Message:      "attempting to handshake but not in unconnected state",
+			CurrentState: current,
+			FromState:    from,
+			ToState:      to,
 		},
 	}
 }
 
-// ErrBadConnect is returned when trying to connected but not connecting
-type ErrBadConnect struct {
-	*ErrBadState
+// BadConnectionError is returned when trying to connected but not connecting
+type BadConnectionError struct {
+	*BadStateError
 }
 
-func newBadConnect(current, from, to int32) *ErrBadConnect {
-	return &ErrBadConnect{
-		&ErrBadState{
-			msg:           "invalid state for successful connect response event",
-			CurrenctState: current,
-			FromState:     from,
-			ToState:       to,
+func newBadConnection(current, from, to int32) *BadConnectionError {
+	return &BadConnectionError{
+		&BadStateError{
+			Message:      "invalid state for successful connect response event",
+			CurrentState: current,
+			FromState:    from,
+			ToState:      to,
 		},
 	}
 }
 
-// ErrUnknownEventType is returned when the next state is unknown
-type ErrUnknownEventType string
+// UnknownEventTypeError is returned when the next state is unknown
+type UnknownEventTypeError struct {
+	Event
+}
 
-func (e ErrUnknownEventType) Error() string {
-	return fmt.Sprintf("unknown event type (%q)", string(e))
+func (e UnknownEventTypeError) Error() string {
+	return fmt.Sprintf("unknown event type (%q)", e.Event)
 }

--- a/extensions/replay/replay.go
+++ b/extensions/replay/replay.go
@@ -7,8 +7,8 @@
 //
 // Example Usage:
 //
-//    client := gobayeux.NewClient(serverAddress)
-//    client.UseExtension(replay.New(replay.NewMapStorage()))
+//	client := gobayeux.NewClient(serverAddress)
+//	client.UseExtension(replay.New(replay.NewMapStorage()))
 package replay
 
 import (

--- a/extensions/salesforce/salesforce.go
+++ b/extensions/salesforce/salesforce.go
@@ -3,7 +3,7 @@
 //
 // An example usage looks like:
 //
-//     client := gobayeux.NewClient(serverAddress, gobayeux.WithHTTPTransport(salesforce.StaticTokenAuthenticator{myToken, http.DefaultTransport}))
+//	client := gobayeux.NewClient(serverAddress, gobayeux.WithHTTPTransport(salesforce.StaticTokenAuthenticator{myToken, http.DefaultTransport}))
 package salesforce
 
 import (

--- a/message.go
+++ b/message.go
@@ -2,7 +2,6 @@ package gobayeux
 
 import (
 	"encoding/json"
-	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -115,7 +114,7 @@ func (m *Message) ParseError() (MessageError, error) {
 	// TODO(sigmavirus24) actually parse the error
 	pieces := strings.SplitN(m.Error, ":", 3)
 	if len(pieces) != 3 {
-		return MessageError{}, fmt.Errorf("error message not parseable: %s", m.Error)
+		return MessageError{}, ErrMessageUnparsable(m.Error)
 	}
 	errorCode, err := strconv.Atoi(pieces[0])
 	if err != nil {

--- a/message_builders.go
+++ b/message_builders.go
@@ -42,7 +42,7 @@ func (b *HandshakeRequestBuilder) AddSupportedConnectionType(connectionType stri
 		}
 		b.supportedConnectionTypes = append(b.supportedConnectionTypes, connectionType)
 	default:
-		return ErrBadConnectionType{connectionType}
+		return BadConnectionTypeError{connectionType}
 	}
 	return nil
 }
@@ -117,7 +117,7 @@ func (b *ConnectRequestBuilder) AddConnectionType(connectionType string) error {
 	case ConnectionTypeCallbackPolling, ConnectionTypeLongPolling, ConnectionTypeIFrame:
 		b.connectionType = connectionType
 	default:
-		return ErrBadConnectionType{connectionType}
+		return BadConnectionTypeError{connectionType}
 	}
 	return nil
 }
@@ -168,7 +168,7 @@ func (b *SubscribeRequestBuilder) AddClientID(clientID string) {
 // sent in a /meta/subscribe request
 func (b *SubscribeRequestBuilder) AddSubscription(c Channel) error {
 	if !c.IsValid() {
-		return ErrInvalidChannel{c}
+		return InvalidChannelError{c}
 	}
 
 	for _, s := range b.subscription {
@@ -187,7 +187,7 @@ func (b *SubscribeRequestBuilder) Build() ([]Message, error) {
 	}
 
 	if len(b.subscription) < 1 {
-		return nil, ErrEmptySlice("subscriptions")
+		return nil, EmptySliceError("subscriptions")
 	}
 
 	ms := make([]Message, len(b.subscription))
@@ -229,7 +229,7 @@ func (b *UnsubscribeRequestBuilder) AddClientID(clientID string) {
 // sent in a /meta/unsubscribe request
 func (b *UnsubscribeRequestBuilder) AddSubscription(c Channel) error {
 	if !c.IsValid() {
-		return ErrInvalidChannel{c}
+		return InvalidChannelError{c}
 	}
 
 	for _, s := range b.subscription {
@@ -248,7 +248,7 @@ func (b *UnsubscribeRequestBuilder) Build() ([]Message, error) {
 	}
 
 	if len(b.subscription) < 1 {
-		return nil, ErrEmptySlice("subscriptions")
+		return nil, EmptySliceError("subscriptions")
 	}
 
 	ms := make([]Message, len(b.subscription))
@@ -294,12 +294,12 @@ func (b *DisconnectRequestBuilder) Build() ([]Message, error) {
 
 func validateVersion(version string) error {
 	if len(version) < 1 {
-		return ErrBadConnectionVersion{version}
+		return BadConnectionVersionError{version}
 	}
 
 	pieces := strings.SplitN(version, ".", 2)
 	if _, err := strconv.Atoi(pieces[0]); err != nil {
-		return ErrBadConnectionVersion{version}
+		return BadConnectionVersionError{version}
 	}
 
 	return nil

--- a/message_builders.go
+++ b/message_builders.go
@@ -1,8 +1,6 @@
 package gobayeux
 
 import (
-	"errors"
-	"fmt"
 	"strconv"
 	"strings"
 )
@@ -44,7 +42,7 @@ func (b *HandshakeRequestBuilder) AddSupportedConnectionType(connectionType stri
 		}
 		b.supportedConnectionTypes = append(b.supportedConnectionTypes, connectionType)
 	default:
-		return fmt.Errorf("'%s' is not a valid connection type", connectionType)
+		return ErrBadConnectionType{connectionType}
 	}
 	return nil
 }
@@ -52,26 +50,20 @@ func (b *HandshakeRequestBuilder) AddSupportedConnectionType(connectionType stri
 // AddVersion accepts the version of the Bayeux protocol that the client
 // supports.
 func (b *HandshakeRequestBuilder) AddVersion(version string) error {
-	if len(version) < 1 {
-		return fmt.Errorf("version '%s' is invalid for Bayeux protocol", version)
-	}
-	pieces := strings.SplitN(version, ".", 2)
-	if _, err := strconv.Atoi(pieces[0]); err != nil {
+	if err := validateVersion(version); err != nil {
 		return err
 	}
+
 	b.version = version
 	return nil
 }
 
 // AddMinimumVersion adds the minimum supported version
 func (b *HandshakeRequestBuilder) AddMinimumVersion(version string) error {
-	if len(version) < 1 {
-		return fmt.Errorf("version '%s' is invalid for Bayeux protocol", version)
-	}
-	pieces := strings.SplitN(version, ".", 2)
-	if _, err := strconv.Atoi(pieces[0]); err != nil {
+	if err := validateVersion(version); err != nil {
 		return err
 	}
+
 	b.minimumVersion = version
 	return nil
 }
@@ -79,10 +71,10 @@ func (b *HandshakeRequestBuilder) AddMinimumVersion(version string) error {
 // Build generates the final Message to be sent as a Handshake Request
 func (b *HandshakeRequestBuilder) Build() ([]Message, error) {
 	if len(b.supportedConnectionTypes) < 1 {
-		return nil, errors.New("no supported connection types provided")
+		return nil, ErrNoSupportedConnectionTypes
 	}
 	if len(b.version) == 0 {
-		return nil, errors.New("no version specified")
+		return nil, ErrNoVersion
 	}
 	m := Message{
 		Channel:                  MetaHandshake,
@@ -125,7 +117,7 @@ func (b *ConnectRequestBuilder) AddConnectionType(connectionType string) error {
 	case ConnectionTypeCallbackPolling, ConnectionTypeLongPolling, ConnectionTypeIFrame:
 		b.connectionType = connectionType
 	default:
-		return fmt.Errorf("'%s' is not a valid connection type", connectionType)
+		return ErrBadConnectionType{connectionType}
 	}
 	return nil
 }
@@ -135,11 +127,11 @@ func (b *ConnectRequestBuilder) AddConnectionType(connectionType string) error {
 // Build generates the final Message to be sent as a Connect Request
 func (b *ConnectRequestBuilder) Build() ([]Message, error) {
 	if b.clientID == "" {
-		return nil, errors.New("missing clientID value")
+		return nil, ErrMissingClientID
 	}
 
 	if b.connectionType == "" {
-		return nil, errors.New("missing connectionType value")
+		return nil, ErrMissingConnectionType
 	}
 
 	m := Message{
@@ -176,7 +168,7 @@ func (b *SubscribeRequestBuilder) AddClientID(clientID string) {
 // sent in a /meta/subscribe request
 func (b *SubscribeRequestBuilder) AddSubscription(c Channel) error {
 	if !c.IsValid() {
-		return fmt.Errorf("channel %s appears to not be a valid channel", c)
+		return ErrInvalidChannel{c}
 	}
 
 	for _, s := range b.subscription {
@@ -191,11 +183,11 @@ func (b *SubscribeRequestBuilder) AddSubscription(c Channel) error {
 // Build generates the final Message to be sent as a Subscribe Request
 func (b *SubscribeRequestBuilder) Build() ([]Message, error) {
 	if b.clientID == "" {
-		return nil, errors.New("missing clientID value")
+		return nil, ErrMissingClientID
 	}
 
 	if len(b.subscription) < 1 {
-		return nil, errors.New("no subscriptions provided")
+		return nil, ErrEmptySlice("subscriptions")
 	}
 
 	ms := make([]Message, len(b.subscription))
@@ -237,7 +229,7 @@ func (b *UnsubscribeRequestBuilder) AddClientID(clientID string) {
 // sent in a /meta/unsubscribe request
 func (b *UnsubscribeRequestBuilder) AddSubscription(c Channel) error {
 	if !c.IsValid() {
-		return fmt.Errorf("channel %s appears to not be a valid channel", c)
+		return ErrInvalidChannel{c}
 	}
 
 	for _, s := range b.subscription {
@@ -252,11 +244,11 @@ func (b *UnsubscribeRequestBuilder) AddSubscription(c Channel) error {
 // Build generates the final Message to be sent as a Unsubscribe Request
 func (b *UnsubscribeRequestBuilder) Build() ([]Message, error) {
 	if b.clientID == "" {
-		return nil, errors.New("missing clientID value")
+		return nil, ErrMissingClientID
 	}
 
 	if len(b.subscription) < 1 {
-		return nil, errors.New("no subscriptions provided")
+		return nil, ErrEmptySlice("subscriptions")
 	}
 
 	ms := make([]Message, len(b.subscription))
@@ -294,8 +286,21 @@ func (b *DisconnectRequestBuilder) AddClientID(clientID string) {
 // Build generates the final Message to be sent as a Disconnect Request
 func (b *DisconnectRequestBuilder) Build() ([]Message, error) {
 	if b.clientID == "" {
-		return nil, errors.New("missing clientID value")
+		return nil, ErrMissingClientID
 	}
 
 	return []Message{{Channel: MetaDisconnect, ClientID: b.clientID}}, nil
+}
+
+func validateVersion(version string) error {
+	if len(version) < 1 {
+		return ErrBadConnectionVersion{version}
+	}
+
+	pieces := strings.SplitN(version, ".", 2)
+	if _, err := strconv.Atoi(pieces[0]); err != nil {
+		return ErrBadConnectionVersion{version}
+	}
+
+	return nil
 }

--- a/state_machine.go
+++ b/state_machine.go
@@ -14,7 +14,13 @@ const (
 	connected
 )
 
-var stateNames = []string{"unconnected", "connecting", "connected"}
+const (
+	unconnectedRepr StateRepresentation = "UNCONNECTED"
+	connectingRepr  StateRepresentation = "CONNECTING"
+	connectedRepr   StateRepresentation = "CONNECTED"
+)
+
+var stateNames = []StateRepresentation{unconnectedRepr, connectingRepr, connectedRepr}
 
 func stateName(state int32) string {
 	s := int(state)
@@ -22,14 +28,8 @@ func stateName(state int32) string {
 		return "unknown"
 	}
 
-	return stateNames[s]
+	return string(stateNames[s])
 }
-
-const (
-	unconnectedRepr StateRepresentation = "UNCONNECTED"
-	connectingRepr  StateRepresentation = "CONNECTING"
-	connectedRepr   StateRepresentation = "CONNECTED"
-)
 
 // Event represents and event that can change the state of a state machine
 type Event string

--- a/state_machine.go
+++ b/state_machine.go
@@ -80,13 +80,13 @@ func (csm *ConnectionStateMachine) ProcessEvent(e Event) error {
 	switch e {
 	case handshakeSent:
 		if !atomic.CompareAndSwapInt32(csm.currentState, unconnected, connecting) {
-			return newBadHanshake(*csm.currentState, unconnected, connecting)
+			return newBadHanshake(atomic.LoadInt32(csm.currentState), unconnected, connecting)
 		}
 	case timeout:
 		atomic.SwapInt32(csm.currentState, unconnected)
 	case successfullyConnected:
 		if !atomic.CompareAndSwapInt32(csm.currentState, connecting, connected) {
-			return newBadConnection(*csm.currentState, connecting, connected)
+			return newBadConnection(atomic.LoadInt32(csm.currentState), connecting, connected)
 		}
 	case disconnectSent:
 		currentState := atomic.LoadInt32(csm.currentState)

--- a/state_machine.go
+++ b/state_machine.go
@@ -86,7 +86,7 @@ func (csm *ConnectionStateMachine) ProcessEvent(e Event) error {
 		atomic.SwapInt32(csm.currentState, unconnected)
 	case successfullyConnected:
 		if !atomic.CompareAndSwapInt32(csm.currentState, connecting, connected) {
-			return newBadConnect(*csm.currentState, connecting, connected)
+			return newBadConnection(*csm.currentState, connecting, connected)
 		}
 	case disconnectSent:
 		currentState := atomic.LoadInt32(csm.currentState)
@@ -94,7 +94,7 @@ func (csm *ConnectionStateMachine) ProcessEvent(e Event) error {
 			atomic.StoreInt32(csm.currentState, unconnected)
 		}
 	default:
-		return ErrUnknownEventType(e)
+		return UnknownEventTypeError{e}
 	}
 	return nil
 }


### PR DESCRIPTION
This makes it easier for users to compare to known error types instead of parsing strings, and where it makes sense additional data is returned to aid with error handling and debugging.