### PR TITLE
Return body with BadResponseError.

### DIFF
--- a/v2/errors.go
+++ b/v2/errors.go
@@ -148,6 +148,7 @@ func (e AlreadyRegisteredError) Error() string {
 type BadResponseError struct {
 	StatusCode int
 	Status     string
+	Body       []byte
 }
 
 func (e BadResponseError) Error() string {


### PR DESCRIPTION
This allows the response body to be inspected when handling errors to get additional details.

ex. Salesforce returns additional details in the error response (https://sfdc.co/streaming-error-codes)