### PR TITLE
Add Logger Interface

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,9 @@
+v2.3.0
+------
+
+- Use a `Logger` interface instead of logrus.FieldLogger directly to allow for
+  other loggers to be passed in.
+
 v2.2.0
 ------
 

--- a/v2/bayeux_client.go
+++ b/v2/bayeux_client.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sirupsen/logrus"
 	"golang.org/x/net/publicsuffix"
 )
 
@@ -22,11 +21,11 @@ type BayeuxClient struct {
 	serverAddress *url.URL
 	state         *clientState
 	exts          []MessageExtender
-	logger        logrus.FieldLogger
+	logger        Logger
 }
 
 // NewBayeuxClient initializes a BayeuxClient for the user
-func NewBayeuxClient(client *http.Client, transport http.RoundTripper, serverAddress string, logger logrus.FieldLogger) (*BayeuxClient, error) {
+func NewBayeuxClient(client *http.Client, transport http.RoundTripper, serverAddress string, logger Logger) (*BayeuxClient, error) {
 	if client == nil {
 		client = http.DefaultClient
 
@@ -47,7 +46,7 @@ func NewBayeuxClient(client *http.Client, transport http.RoundTripper, serverAdd
 	}
 
 	if logger == nil {
-		logger = logrus.New()
+		logger = newNullLogger()
 	}
 
 	return &BayeuxClient{

--- a/v2/logger.go
+++ b/v2/logger.go
@@ -1,0 +1,65 @@
+package gobayeux
+
+import "github.com/sirupsen/logrus"
+
+// Logger defines the logging interface gobayeux leverages
+type Logger interface {
+	// Debug takes any number of arguments and logs them at the debug level
+	Debug(args ...any)
+
+	// Info takes any number of arguments and logs them at the info level
+	Info(args ...any)
+
+	// Warn takes any number of arguments and logs them at the info level
+	Warn(args ...any)
+
+	// Error takes any number of arguments and logs them at the info level
+	Error(args ...any)
+
+	// WithError returns a new Logger that addes the given error to any log
+	// messages emitted
+	WithError(error) Logger
+
+	// WithField returns a new Logger that adds the given key/value to any
+	// log messages emitted
+	WithField(key string, value any) Logger
+}
+
+type nullLogger struct {
+}
+
+func (*nullLogger) Debug(args ...any) {
+}
+
+func (*nullLogger) Info(args ...any) {
+}
+
+func (*nullLogger) Warn(args ...any) {
+}
+
+func (*nullLogger) Error(args ...any) {
+}
+
+func (l *nullLogger) WithError(err error) Logger {
+	return l
+}
+
+func (l *nullLogger) WithField(key string, value any) Logger {
+	return l
+}
+
+func newNullLogger() *nullLogger {
+	return &nullLogger{}
+}
+
+type wrappedFieldLogger struct {
+	logrus.FieldLogger
+}
+
+func (w *wrappedFieldLogger) WithError(err error) Logger {
+	return &wrappedFieldLogger{w.FieldLogger.WithError(err)}
+}
+
+func (w *wrappedFieldLogger) WithField(key string, value any) Logger {
+	return &wrappedFieldLogger{w.FieldLogger.WithField(key, value)}
+}

--- a/v2/logger.go
+++ b/v2/logger.go
@@ -4,17 +4,21 @@ import "github.com/sirupsen/logrus"
 
 // Logger defines the logging interface gobayeux leverages
 type Logger interface {
-	// Debug takes any number of arguments and logs them at the debug level
-	Debug(args ...any)
+	// Debug takes a message and any number of arguments and logs them at the
+	// debug level
+	Debug(msg string, args ...any)
 
-	// Info takes any number of arguments and logs them at the info level
-	Info(args ...any)
+	// Info takes a message and any number of arguments and logs them at the
+	// info level
+	Info(msg string, args ...any)
 
-	// Warn takes any number of arguments and logs them at the info level
-	Warn(args ...any)
+	// Warn takes a message and any number of arguments and logs them at the
+	// warn level
+	Warn(msg string, args ...any)
 
-	// Error takes any number of arguments and logs them at the info level
-	Error(args ...any)
+	// Error takes a message and any number of arguments and logs them at the
+	// error level
+	Error(msg string, args ...any)
 
 	// WithError returns a new Logger that addes the given error to any log
 	// messages emitted
@@ -28,16 +32,16 @@ type Logger interface {
 type nullLogger struct {
 }
 
-func (*nullLogger) Debug(args ...any) {
+func (*nullLogger) Debug(msg string, args ...any) {
 }
 
-func (*nullLogger) Info(args ...any) {
+func (*nullLogger) Info(msg string, args ...any) {
 }
 
-func (*nullLogger) Warn(args ...any) {
+func (*nullLogger) Warn(msg string, args ...any) {
 }
 
-func (*nullLogger) Error(args ...any) {
+func (*nullLogger) Error(msg string, args ...any) {
 }
 
 func (l *nullLogger) WithError(err error) Logger {
@@ -54,6 +58,22 @@ func newNullLogger() *nullLogger {
 
 type wrappedFieldLogger struct {
 	logrus.FieldLogger
+}
+
+func (w *wrappedFieldLogger) Debug(msg string, args ...any) {
+	w.FieldLogger.Debug(append([]any{msg}, args...))
+}
+
+func (w *wrappedFieldLogger) Info(msg string, args ...any) {
+	w.FieldLogger.Info(append([]any{msg}, args...))
+}
+
+func (w *wrappedFieldLogger) Warn(msg string, args ...any) {
+	w.FieldLogger.Warn(append([]any{msg}, args...))
+}
+
+func (w *wrappedFieldLogger) Error(msg string, args ...any) {
+	w.FieldLogger.Error(append([]any{msg}, args...))
 }
 
 func (w *wrappedFieldLogger) WithError(err error) Logger {

--- a/v2/slog.go
+++ b/v2/slog.go
@@ -1,0 +1,24 @@
+//go:build go1.21
+// +build go1.21
+
+package gobayeux
+
+import "log/slog"
+
+type wrappedSlog struct {
+	*slog.Logger
+}
+
+func (w *wrappedSlog) WithError(err error) Logger {
+	return w.WithField("error", err)
+}
+
+func (w *wrappedSlog) WithField(key string, value any) Logger {
+	return &wrappedSlog{w.With(slog.Any(key, value))}
+}
+
+func WithSlogLogger(logger *slog.Logger) Option {
+	return func(options *Options) {
+		options.Logger = &wrappedSlog{logger}
+	}
+}

--- a/v2/slog_test.go
+++ b/v2/slog_test.go
@@ -29,6 +29,9 @@ func ExampleWithSlogLogger() {
 
 	errs := client.Start(context.Background())
 	err = <-errs
+	if err == nil {
+		panic("expected an error when connecting")
+	}
 	// Output:
 	// level=DEBUG msg=starting at=handshake
 	// level=DEBUG msg="error during request" at=handshake error="Post \"http://localhost:9876\": dial tcp 127.0.0.1:9876: connect: connection refused"

--- a/v2/slog_test.go
+++ b/v2/slog_test.go
@@ -22,7 +22,7 @@ func ExampleWithSlogLogger() {
 			return a
 		},
 	}))
-	client, err := gobayeux.NewClient("http://localhost:9876", gobayeux.WithSlogLogger(logger))
+	client, err := gobayeux.NewClient("http://127.0.0.1:9876", gobayeux.WithSlogLogger(logger))
 	if err != nil {
 		panic(err)
 	}
@@ -34,5 +34,5 @@ func ExampleWithSlogLogger() {
 	}
 	// Output:
 	// level=DEBUG msg=starting at=handshake
-	// level=DEBUG msg="error during request" at=handshake error="Post \"http://localhost:9876\": dial tcp 127.0.0.1:9876: connect: connection refused"
+	// level=DEBUG msg="error during request" at=handshake error="Post \"http://127.0.0.1:9876\": dial tcp 127.0.0.1:9876: connect: connection refused"
 }

--- a/v2/slog_test.go
+++ b/v2/slog_test.go
@@ -1,0 +1,35 @@
+//go:build go1.21
+// +build go1.21
+
+package gobayeux_test
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	"github.com/sigmavirus24/gobayeux/v2"
+)
+
+func ExampleWithSlogLogger() {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+			if a.Key == slog.TimeKey {
+				return slog.Attr{}
+			}
+
+			return a
+		},
+	}))
+	client, err := gobayeux.NewClient("http://localhost:9876", gobayeux.WithSlogLogger(logger))
+	if err != nil {
+		panic(err)
+	}
+
+	errs := client.Start(context.Background())
+	err = <-errs
+	// Output:
+	// level=DEBUG msg=starting at=handshake
+	// level=DEBUG msg="error during request" at=handshake error="Post \"http://localhost:9876\": dial tcp 127.0.0.1:9876: connect: connection refused"
+}


### PR DESCRIPTION
Use a `Logger` interface instead of `logrus.FieldLogger` so that other loggers can be provided.