### PR TITLE
Create a new http.Client for each BayeuxClient.

### DIFF
--- a/v2/bayeux_client.go
+++ b/v2/bayeux_client.go
@@ -27,13 +27,17 @@ type BayeuxClient struct {
 // NewBayeuxClient initializes a BayeuxClient for the user
 func NewBayeuxClient(client *http.Client, transport http.RoundTripper, serverAddress string, logger Logger) (*BayeuxClient, error) {
 	if client == nil {
-		client = http.DefaultClient
-
 		jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
 		if err != nil {
 			return nil, err
 		}
-		client.Jar = jar
+
+		client = &http.Client{
+			Transport:     http.DefaultClient.Transport,
+			CheckRedirect: http.DefaultClient.CheckRedirect,
+			Jar:           jar,
+			Timeout:       http.DefaultClient.Timeout,
+		}
 	}
 	if transport == nil {
 		transport = http.DefaultTransport


### PR DESCRIPTION
Prevents clobbering cookie jars between clients which will trigger [XSS](https://docs.cometd.org/current4/reference/#_security_xss) protection on the server side.